### PR TITLE
feat(*): update php and output

### DIFF
--- a/README.md
+++ b/README.md
@@ -21,14 +21,26 @@ Starting build... but first, coffee!
 -----> PHP app detected
 -----> Bootstrapping...
 -----> Installing platform packages...
-       - php (7.0.7)
+       - php (7.0.9)
        - apache (2.4.20)
        - nginx (1.8.1)
 -----> Installing dependencies...
-       Composer version 1.0.3 2016-04-29 16:30:15
+       Composer version 1.1.3 2016-06-26 15:42:08
        Loading composer repositories with package information
        Installing dependencies from lock file
-       - Installing slim/slim (2.6.2)
+       - Installing psr/http-message (1.0.1)
+       Downloading: 100%
+
+       - Installing pimple/pimple (v3.0.2)
+       Downloading: 100%
+
+       - Installing nikic/fast-route (v1.0.1)
+       Downloading: 100%
+
+       - Installing container-interop/container-interop (1.1.0)
+       Downloading: 100%
+
+       - Installing slim/slim (3.5.0)
        Downloading: 100%
 
        Generating optimized autoload files
@@ -49,8 +61,8 @@ To learn more, use 'deis help' or visit https://deis.com/
 To ssh://git@deis-builder.deis.rocks:2222/zanier-zeppelin.git
  * [new branch]      master -> master
 $ curl http://zanier-zeppelin.deis.rocks
-Powered by Deis!
-Running on container ID zanier-zeppelin-v2-web-dbj92
+Powered by Deis
+Release v2 on zanier-zeppelin-web-2969858146-wv4ss
 ```
 
 ## Additional Resources

--- a/composer.json
+++ b/composer.json
@@ -5,10 +5,10 @@
     "version": "1.0.1",
     "homepage": "https://github.com/deis/example-php",
     "require": {
-        "php": ">=5.5",
-        "slim/slim": "~2.6"
+        "php": "~7.0",
+        "slim/slim": "~3.5"
     },
     "require-dev": {
-        "heroku/heroku-buildpack-php": "v67"
+        "heroku/heroku-buildpack-php": "v109"
     }
 }

--- a/composer.lock
+++ b/composer.lock
@@ -4,32 +4,105 @@
         "Read more about it at https://getcomposer.org/doc/01-basic-usage.md#composer-lock-the-lock-file",
         "This file is @generated automatically"
     ],
-    "hash": "31f7adc0c2c97360c3a3ea960ba0e96b",
+    "hash": "427db91e4b5ad6aae88a0599be2c3445",
+    "content-hash": "1958150e5e5c678e943d7589dde99564",
     "packages": [
         {
-            "name": "slim/slim",
-            "version": "2.6.2",
+            "name": "container-interop/container-interop",
+            "version": "1.1.0",
             "source": {
                 "type": "git",
-                "url": "https://github.com/slimphp/Slim.git",
-                "reference": "20a02782f76830b67ae56a5c08eb1f563c351a37"
+                "url": "https://github.com/container-interop/container-interop.git",
+                "reference": "fc08354828f8fd3245f77a66b9e23a6bca48297e"
             },
             "dist": {
                 "type": "zip",
-                "url": "https://api.github.com/repos/slimphp/Slim/zipball/20a02782f76830b67ae56a5c08eb1f563c351a37",
-                "reference": "20a02782f76830b67ae56a5c08eb1f563c351a37",
+                "url": "https://api.github.com/repos/container-interop/container-interop/zipball/fc08354828f8fd3245f77a66b9e23a6bca48297e",
+                "reference": "fc08354828f8fd3245f77a66b9e23a6bca48297e",
+                "shasum": ""
+            },
+            "type": "library",
+            "autoload": {
+                "psr-4": {
+                    "Interop\\Container\\": "src/Interop/Container/"
+                }
+            },
+            "notification-url": "https://packagist.org/downloads/",
+            "license": [
+                "MIT"
+            ],
+            "description": "Promoting the interoperability of container objects (DIC, SL, etc.)",
+            "time": "2014-12-30 15:22:37"
+        },
+        {
+            "name": "nikic/fast-route",
+            "version": "v1.0.1",
+            "source": {
+                "type": "git",
+                "url": "https://github.com/nikic/FastRoute.git",
+                "reference": "8ea928195fa9b907f0d6e48312d323c1a13cc2af"
+            },
+            "dist": {
+                "type": "zip",
+                "url": "https://api.github.com/repos/nikic/FastRoute/zipball/8ea928195fa9b907f0d6e48312d323c1a13cc2af",
+                "reference": "8ea928195fa9b907f0d6e48312d323c1a13cc2af",
+                "shasum": ""
+            },
+            "require": {
+                "php": ">=5.4.0"
+            },
+            "type": "library",
+            "autoload": {
+                "psr-4": {
+                    "FastRoute\\": "src/"
+                },
+                "files": [
+                    "src/functions.php"
+                ]
+            },
+            "notification-url": "https://packagist.org/downloads/",
+            "license": [
+                "BSD-3-Clause"
+            ],
+            "authors": [
+                {
+                    "name": "Nikita Popov",
+                    "email": "nikic@php.net"
+                }
+            ],
+            "description": "Fast request router for PHP",
+            "keywords": [
+                "router",
+                "routing"
+            ],
+            "time": "2016-06-12 19:08:51"
+        },
+        {
+            "name": "pimple/pimple",
+            "version": "v3.0.2",
+            "source": {
+                "type": "git",
+                "url": "https://github.com/silexphp/Pimple.git",
+                "reference": "a30f7d6e57565a2e1a316e1baf2a483f788b258a"
+            },
+            "dist": {
+                "type": "zip",
+                "url": "https://api.github.com/repos/silexphp/Pimple/zipball/a30f7d6e57565a2e1a316e1baf2a483f788b258a",
+                "reference": "a30f7d6e57565a2e1a316e1baf2a483f788b258a",
                 "shasum": ""
             },
             "require": {
                 "php": ">=5.3.0"
             },
-            "suggest": {
-                "ext-mcrypt": "Required for HTTP cookie encryption"
-            },
             "type": "library",
+            "extra": {
+                "branch-alias": {
+                    "dev-master": "3.0.x-dev"
+                }
+            },
             "autoload": {
                 "psr-0": {
-                    "Slim": "."
+                    "Pimple": "src/"
                 }
             },
             "notification-url": "https://packagist.org/downloads/",
@@ -38,34 +111,152 @@
             ],
             "authors": [
                 {
-                    "name": "Josh Lockhart",
-                    "email": "info@joshlockhart.com",
-                    "homepage": "http://www.joshlockhart.com/"
+                    "name": "Fabien Potencier",
+                    "email": "fabien@symfony.com"
                 }
             ],
-            "description": "Slim Framework, a PHP micro framework",
-            "homepage": "http://github.com/codeguy/Slim",
+            "description": "Pimple, a simple Dependency Injection Container",
+            "homepage": "http://pimple.sensiolabs.org",
             "keywords": [
-                "microframework",
-                "rest",
+                "container",
+                "dependency injection"
+            ],
+            "time": "2015-09-11 15:10:35"
+        },
+        {
+            "name": "psr/http-message",
+            "version": "1.0.1",
+            "source": {
+                "type": "git",
+                "url": "https://github.com/php-fig/http-message.git",
+                "reference": "f6561bf28d520154e4b0ec72be95418abe6d9363"
+            },
+            "dist": {
+                "type": "zip",
+                "url": "https://api.github.com/repos/php-fig/http-message/zipball/f6561bf28d520154e4b0ec72be95418abe6d9363",
+                "reference": "f6561bf28d520154e4b0ec72be95418abe6d9363",
+                "shasum": ""
+            },
+            "require": {
+                "php": ">=5.3.0"
+            },
+            "type": "library",
+            "extra": {
+                "branch-alias": {
+                    "dev-master": "1.0.x-dev"
+                }
+            },
+            "autoload": {
+                "psr-4": {
+                    "Psr\\Http\\Message\\": "src/"
+                }
+            },
+            "notification-url": "https://packagist.org/downloads/",
+            "license": [
+                "MIT"
+            ],
+            "authors": [
+                {
+                    "name": "PHP-FIG",
+                    "homepage": "http://www.php-fig.org/"
+                }
+            ],
+            "description": "Common interface for HTTP messages",
+            "homepage": "https://github.com/php-fig/http-message",
+            "keywords": [
+                "http",
+                "http-message",
+                "psr",
+                "psr-7",
+                "request",
+                "response"
+            ],
+            "time": "2016-08-06 14:39:51"
+        },
+        {
+            "name": "slim/slim",
+            "version": "3.5.0",
+            "source": {
+                "type": "git",
+                "url": "https://github.com/slimphp/Slim.git",
+                "reference": "184352bc1913d7ba552ab4131d62f4730ddb0893"
+            },
+            "dist": {
+                "type": "zip",
+                "url": "https://api.github.com/repos/slimphp/Slim/zipball/184352bc1913d7ba552ab4131d62f4730ddb0893",
+                "reference": "184352bc1913d7ba552ab4131d62f4730ddb0893",
+                "shasum": ""
+            },
+            "require": {
+                "container-interop/container-interop": "^1.1",
+                "nikic/fast-route": "^1.0",
+                "php": ">=5.5.0",
+                "pimple/pimple": "^3.0",
+                "psr/http-message": "^1.0"
+            },
+            "provide": {
+                "psr/http-message-implementation": "1.0"
+            },
+            "require-dev": {
+                "phpunit/phpunit": "^4.0",
+                "squizlabs/php_codesniffer": "^2.5"
+            },
+            "type": "library",
+            "autoload": {
+                "psr-4": {
+                    "Slim\\": "Slim"
+                }
+            },
+            "notification-url": "https://packagist.org/downloads/",
+            "license": [
+                "MIT"
+            ],
+            "authors": [
+                {
+                    "name": "Rob Allen",
+                    "email": "rob@akrabat.com",
+                    "homepage": "http://akrabat.com"
+                },
+                {
+                    "name": "Josh Lockhart",
+                    "email": "hello@joshlockhart.com",
+                    "homepage": "https://joshlockhart.com"
+                },
+                {
+                    "name": "Gabriel Manricks",
+                    "email": "gmanricks@me.com",
+                    "homepage": "http://gabrielmanricks.com"
+                },
+                {
+                    "name": "Andrew Smith",
+                    "email": "a.smith@silentworks.co.uk",
+                    "homepage": "http://silentworks.co.uk"
+                }
+            ],
+            "description": "Slim is a PHP micro framework that helps you quickly write simple yet powerful web applications and APIs",
+            "homepage": "http://slimframework.com",
+            "keywords": [
+                "api",
+                "framework",
+                "micro",
                 "router"
             ],
-            "time": "2015-03-08 18:41:17"
+            "time": "2016-07-26 15:12:13"
         }
     ],
     "packages-dev": [
         {
             "name": "heroku/heroku-buildpack-php",
-            "version": "v67",
+            "version": "v109",
             "source": {
                 "type": "git",
                 "url": "https://github.com/heroku/heroku-buildpack-php.git",
-                "reference": "8da6b92aad89b2e7254f5eb2ad39ffac315b2282"
+                "reference": "cd2d13992b72d049aa270d4b745aae6329e0c037"
             },
             "dist": {
                 "type": "zip",
-                "url": "https://api.github.com/repos/heroku/heroku-buildpack-php/zipball/8da6b92aad89b2e7254f5eb2ad39ffac315b2282",
-                "reference": "8da6b92aad89b2e7254f5eb2ad39ffac315b2282",
+                "url": "https://api.github.com/repos/heroku/heroku-buildpack-php/zipball/cd2d13992b72d049aa270d4b745aae6329e0c037",
+                "reference": "cd2d13992b72d049aa270d4b745aae6329e0c037",
                 "shasum": ""
             },
             "bin": [
@@ -86,7 +277,7 @@
                 }
             ],
             "description": "Toolkit for starting a PHP application locally, with or without foreman, using the same config for PHP/HHVM and Apache2/Nginx as on Heroku",
-            "homepage": "http://github.com/heroku/heroku-buildpack-php",
+            "homepage": "https://github.com/heroku/heroku-buildpack-php",
             "keywords": [
                 "apache",
                 "apache2",
@@ -96,7 +287,7 @@
                 "nginx",
                 "php"
             ],
-            "time": "2015-03-24 19:49:58"
+            "time": "2016-07-21 11:26:05"
         }
     ],
     "aliases": [],
@@ -105,7 +296,7 @@
     "prefer-stable": false,
     "prefer-lowest": false,
     "platform": {
-        "php": ">=5.5"
+        "php": "~7.0"
     },
     "platform-dev": []
 }

--- a/web/.htaccess
+++ b/web/.htaccess
@@ -1,0 +1,4 @@
+RewriteEngine on
+RewriteCond %{REQUEST_FILENAME} !-d
+RewriteCond %{REQUEST_FILENAME} !-f
+RewriteRule . index.php [L]

--- a/web/index.php
+++ b/web/index.php
@@ -1,12 +1,19 @@
 <?php
-
 require('../vendor/autoload.php');
+use Psr\Http\Message\ServerRequestInterface;
+use Psr\Http\Message\ResponseInterface;
 
-$app = new \Slim\Slim();
-$app->get('/', function () {
+$app = new Slim\App();
+
+// This endppint returns 200 for kubernetes healthchecks.
+$app->get('/healthz', function (ServerRequestInterface $request, ResponseInterface $response) {
+    return $response->withStatus(200);
+});
+$app->get('/', function (ServerRequestInterface $request, ResponseInterface $response) {
+    $powered = isset($_ENV["POWERED_BY"]) ? $_ENV['POWERED_BY'] : "Deis";
     $container = trim(exec('hostname') ?: "unknown");
-    echo "Powered by " . (isset($_ENV["POWERED_BY"]) ? $_ENV['POWERED_BY'] : "Deis!") . "\n";
-    echo "Running on container ID " . $container . "\n";
+    $release = isset($_ENV["WORKFLOW_RELEASE"]) ? $_ENV['WORKFLOW_RELEASE'] : "unknown";
+    return $response->withStatus(200)->write("Powered by $powered\nRelease $release on $container\n");
 });
 $app->run();
 


### PR DESCRIPTION
This PR:
- pins php. It was accidentally set to`>=`, meaning that it would use the latest version of php, as opposed to the stable version.
- Updates slim from v2->v3
- Adds a healthcheck url
- Updates `/` to be the same as example-go
- Adds a `.htaccess` to that every URL maps to `web/index.php`, allowing slim to use its router